### PR TITLE
do not load epy-{python,completion,editing,binding} in epy-init.el

### DIFF
--- a/epy-init.el
+++ b/epy-init.el
@@ -10,9 +10,9 @@
 
 (add-to-list 'load-path epy-install-dir)
 (require 'epy-setup)
-(require 'epy-python)
-(require 'epy-completion)
-(require 'epy-editing)
-(require 'epy-bindings)
+;(require 'epy-python)
+;(require 'epy-completion)
+;(require 'epy-editing)
+;(require 'epy-bindings)
 
 (provide 'epy-init)


### PR DESCRIPTION
If we do so, we force all user to use all those module. If we want a subset, we need to modif the source. Anyway the documentation tell that we should enable each of them individually.
