### PR TITLE
Crash on refactoring

### DIFF
--- a/python-libs/rope/base/builtins.py
+++ b/python-libs/rope/base/builtins.py
@@ -120,7 +120,9 @@ def _object_attributes(obj, parent):
     for name in dir(obj):
         if name == 'None':
             continue
-        child = getattr(obj, name)
+        child = getattr(obj, name, None)
+        if child is None:
+        	continue
         pyobject = None
         if inspect.isclass(child):
             pyobject = BuiltinClass(child, {}, parent=parent)


### PR DESCRIPTION
I had this rope bug when I tried to do a Rope refactoring:
https://bitbucket.org/agr/rope/issue/15/crashes-with-attributeerror

I applied their patch and it now works.
