### PR TITLE
Added hash to lambda function to remove compilation warning from eproject

### DIFF
--- a/extensions/eproject/eproject.el
+++ b/extensions/eproject/eproject.el
@@ -800,7 +800,7 @@ for all project files (nil/t).")
 
 (defun prj-list-sorted ()
   (sort (append prj-list nil)
-        '(lambda (a b) (string-lessp (car a) (car b)))
+        #'(lambda (a b) (string-lessp (car a) (car b)))
         ))
 
 (defun prj-setmenu ()


### PR DESCRIPTION
Warning was:
    `"extensions/eproject/eproject.el:Warning: (lambda (a b) ...) quoted with ' rather than with #"`
which was occurring on ubuntu 12.04 emacs-snapshot, but seemingly not on OSX.
