### PR TITLE
Move flymake' temp files into system $TMP directory.

### DIFF
--- a/epy-python.el
+++ b/epy-python.el
@@ -69,10 +69,13 @@
 ;; Flymake additions, I have to put this one somwhere else?
 ;;=========================================================
 
+(defun flymake-create-temp-in-system-tempdir (filename prefix)
+  (make-temp-file (or prefix "flymake")))
+
 (defun flymake-create-copy-file ()
   "Create a copy local file"
   (let* ((temp-file (flymake-init-create-temp-buffer-copy 
-                     'flymake-create-temp-inplace)))
+                     'flymake-create-temp-in-system-tempdir)))
     (file-relative-name 
      temp-file 
      (file-name-directory buffer-file-name))))     


### PR DESCRIPTION
Flymake dies and emacs hangs if I'm trying to open python file:
- on remote system, where no pyflakes installed,
- in directory without write permissions.

This fix moves flymake's temp files into local $TMP directory.
