### PR TITLE
Add key binding for failed nosetests

### DIFF
--- a/epy-nose.el
+++ b/epy-nose.el
@@ -4,6 +4,7 @@
 (add-hook 'python-mode-hook
           (lambda ()
             (local-set-key "\C-ca" 'nosetests-all)
+            (local-set-key "\C-cF" 'nosetests-failed)
             (local-set-key "\C-cM" 'nosetests-module)  ;; C-c m conflicts w/ pylint
             (local-set-key "\C-c." 'nosetests-one)
             (local-set-key "\C-cx" 'nosetests-stop)


### PR DESCRIPTION
Just to have something convenient available by default.